### PR TITLE
Update .env sample. Fixes various bugs. Improve sneed.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,15 +1,20 @@
 # Discord bot token
 TOKEN =abc123
-# Post ID for granting roles based on reactions
-ROLES_POST =12345
+# Post ID for granting roles based on reactions. If the bot will create a new post, set this to 0.
+ROLES_POST =0
 # Server ID
-SERVER_ID =67890
+SERVER_ID =12345
 # Channel ID where the bot should spit out members leaving/banned
-MOD_CHANNEL =13579
+MOD_CHANNEL =12345
 # Role ID for the moderator role
-MOD_ROLE =24680
-# Winghug sticker ID
-WINGHUG_ID = 123456
+MOD_ROLE =12345
+# Channel ID for where to put the rules
+RULES_CHANNEL_ID =12345
+# Rules post. If the bot will create a new post, set this to 0.
+RULES_POST_ID =0
+# Winghug and pills sticker ID
+WINGHUG_ID =12345
+TAKEMEDS_ID =12345
 # Max pings/emoji for a single message
 MAX_PING = 10
 MAX_EMOJI = 20

--- a/FangBot.py
+++ b/FangBot.py
@@ -27,7 +27,7 @@ welcomePost = int(os.getenv("ROLES_POST"))
 winghugId = int(os.getenv("WINGHUG_ID"))
 rulesChanId = int(os.getenv("RULES_CHANNEL_ID"))
 rulesPostId = int(os.getenv("RULES_POST_ID"))
-winghugId = int(os.getenv("WINGHUG_ID"))
+medsId = int(os.getenv("TAKEMEDS_ID"))
 intents = discord.Intents(
     guilds=True,
     members=True,
@@ -37,7 +37,7 @@ intents = discord.Intents(
     guild_reactions=True,
     message_content=True
 )
-bot = dc.Bot(command_prefix="!", intents=intents)
+bot = dc.Bot(command_prefix="!", intents=intents, case_insensitive=True)
 logger = logging.getLogger('discord')
 
 # Remove the built in help command so that we can define a custom help command.
@@ -50,7 +50,11 @@ async def on_command_error(ctx, error):
     elif isinstance(error, dc.CommandOnCooldown):
         await ctx.reply(error)
     else:
-        await ctx.reply(f"Unexpected error: {error}")
+        errorMsg = str(error)
+        errorMsg = re.sub(r'<@!?(\d+)>', r'@member\1', errorMsg) #strip user pings
+        errorMsg = re.sub(r'<@&(\d+)>', r'@role\1', errorMsg) #strip role pings
+        errorMsg = re.sub(r'<#(\d+)>', r'#channel\1', errorMsg) #strip channel pings, probably unnecessary but what the hell
+        await ctx.reply(f"Unexpected error: {errorMsg}")
 
 @bot.event
 async def on_ready():
@@ -194,22 +198,26 @@ async def tail(ctx):
 
 @bot.command(name="sneed")
 async def sneed(ctx):
-    await ctx.send("What you s*need* are your meds, Anon.")
+    s = await bot.get_guild(serverId).fetch_sticker(medsId)
+    userName = ctx.author.nick or ctx.author.display_name
     member = ctx.author
     isJanny = member.get_role(modRole)
+    startingDelta = timedelta(days=1, minutes=1)
+    totalSeconds = startingDelta.total_seconds()
+    chosenSecondsAmount = randrange(1, totalSeconds)
+    timeoutDelta = timedelta(seconds=chosenSecondsAmount)
+    formattedChosenSecondsAmount = format(str(timedelta(seconds=chosenSecondsAmount)))
+    logger.info(f"{member} was timed out for {formattedChosenSecondsAmount} seconds")
+    await ctx.send(f"What you s*need* are your meds, {userName}. These pills should keep you medicated for {formattedChosenSecondsAmount}!", stickers=[s])
     if isJanny == None:
-        startingDelta = timedelta(days=1, minutes=1)
-        totalSeconds = startingDelta.total_seconds()
-        chosenSecondsAmount = randrange(1, totalSeconds)
-        timeoutDelta = timedelta(seconds=chosenSecondsAmount)
-        formattedChosenSecondsAmount = format(str(timedelta(seconds=chosenSecondsAmount)))
-        logger.info(f"{member} was timed out for {formattedChosenSecondsAmount} seconds")
         await member.timeout(timeoutDelta)
 
 @bot.command(name="winghug")
 async def winghug(ctx, *mentions:discord.Member):
     s = await bot.get_guild(serverId).fetch_sticker(winghugId)
     ref = ctx.message.reference
+    print(bot.user.id)
+    print(mentions)
     if ref != None:
         m = await ctx.channel.fetch_message(ref.message_id)
         if m.author == bot.user:
@@ -217,8 +225,11 @@ async def winghug(ctx, *mentions:discord.Member):
         else:
             await ctx.send(stickers=[s], reference=ref)
     elif len(mentions) > 0:
-        userlist = ' '.join([u.mention for u in mentions])
-        await ctx.send(f'{userlist}', stickers=[s])
+        if any(m.id == bot.user.id for m in mentions):
+            await ctx.reply("I'm not hugging myself, dweeb!")
+        else:
+            userlist = ' '.join([u.mention for u in mentions])
+            await ctx.send(f'{userlist}', stickers=[s])
     else:
         await ctx.reply(stickers=[s])
 

--- a/FangBot.py
+++ b/FangBot.py
@@ -219,8 +219,6 @@ async def sneed(ctx):
 async def winghug(ctx, *mentions:discord.Member):
     s = await bot.get_guild(serverId).fetch_sticker(winghugId)
     ref = ctx.message.reference
-    print(bot.user.id)
-    print(mentions)
     if ref != None:
         m = await ctx.channel.fetch_message(ref.message_id)
         if m.author == bot.user:

--- a/FangBot.py
+++ b/FangBot.py
@@ -201,19 +201,22 @@ async def tail(ctx):
 
 @bot.command(name="sneed")
 async def sneed(ctx):
-    s = await bot.get_guild(serverId).fetch_sticker(medsId)
     userName = ctx.author.nick or ctx.author.display_name
     member = ctx.author
     isJanny = member.get_role(modRole)
-    startingDelta = timedelta(days=1, minutes=1)
-    totalSeconds = startingDelta.total_seconds()
-    chosenSecondsAmount = randrange(1, totalSeconds)
-    timeoutDelta = timedelta(seconds=chosenSecondsAmount)
-    formattedChosenSecondsAmount = format(str(timedelta(seconds=chosenSecondsAmount)))
-    logger.info(f"{member} was timed out for {formattedChosenSecondsAmount} seconds")
-    await ctx.send(f"What you s*need* are your meds, {userName}. These pills should keep you medicated for {formattedChosenSecondsAmount}!", stickers=[s])
+    baseMsg = f"What you s*need* are your meds, {userName}." 
     if isJanny == None:
+        s = await bot.get_guild(serverId).fetch_sticker(medsId)
+        startingDelta = timedelta(days=1, minutes=1)
+        totalSeconds = startingDelta.total_seconds()
+        chosenSecondsAmount = randrange(1, totalSeconds)
+        timeoutDelta = timedelta(seconds=chosenSecondsAmount)
+        formattedChosenSecondsAmount = format(str(timedelta(seconds=chosenSecondsAmount)))
+        await ctx.send(f"{baseMsg} These pills should keep you medicated for {formattedChosenSecondsAmount}!", stickers=[s])
         await member.timeout(timeoutDelta)
+        logger.info(f"{member} was timed out for {formattedChosenSecondsAmount} seconds")
+    else:
+        await ctx.send(f"{baseMsg} These pills won't help a janny. You're on your own, dweeb.")
 
 @bot.command(name="winghug")
 async def winghug(ctx, *mentions:discord.Member):


### PR DESCRIPTION
Fixed #10, #11, #13, #14

- .env sample was updated to include a winghug sticker ID. Production environments should update their .env files accordingly. Added some additional info regarding rules/roles posts.
- Winghug now checks if at least one of the pinged users is the bot itself. Bot will give the usual "I'm not hugging myself" message in such cases.
- Unhandled errors now strip user, role, and channel mentions prior to sending the message.
- Sneed command now replies with the timeout duration and the take pills sticker
- Commands made case-insensitive